### PR TITLE
fix modern chair taking over modern table

### DIFF
--- a/src/main/resources/data/cfmrift/recipes/modern_chair.json
+++ b/src/main/resources/data/cfmrift/recipes/modern_chair.json
@@ -14,6 +14,6 @@
         }
     },
     "result": {
-        "item": "cfmrift:modern_table"
+        "item": "cfmrift:modern_chair"
     }
 }


### PR DESCRIPTION
This fixes issue #1. Modern Chair and Modern Table both had cfmrift:modern_table in their result definition.